### PR TITLE
Added Google Cloud authentication secret env

### DIFF
--- a/.github/workflows/manual-quality-control.yml
+++ b/.github/workflows/manual-quality-control.yml
@@ -20,6 +20,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - name: Run Manual QC script
         env:
           SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}


### PR DESCRIPTION
- [X] added Google Cloud authentication secret env

Please note:

Need to add GCP Key under the name `GCP_SA_KEY` in github repo `secrets` environment. 