### PR TITLE
Links Chanaged From MD5 to SHA256

### DIFF
--- a/test_disk_image_downloads.py
+++ b/test_disk_image_downloads.py
@@ -4,15 +4,15 @@ import requests
 def test_shortlinks():
     # Short links in the UI
     PI3_SHORTLINK = "https://go.srly.io/Pi3-20"
-    PI3_SHORTLINK_MD5 = "https://go.srly.io/Pi3-20_md5"
+    PI3_SHORTLINK_SHA256 = "https://go.srly.io/Pi3-20_sha256"
     PI4_SHORTLINK = "https://go.srly.io/RPi4"
-    PI4_SHORTLINK_MD5 = "https://go.srly.io/RPi4_md5"
+    PI4_SHORTLINK_SHA256 = "https://go.srly.io/RPi4_sha256"
 
     # Test the shortlinks for the Pi3 and Pi4
     assert requests.head(PI3_SHORTLINK, allow_redirects=True).status_code == 200
-    assert requests.head(PI3_SHORTLINK_MD5, allow_redirects=True).status_code == 200
+    assert requests.head(PI3_SHORTLINK_SHA256, allow_redirects=True).status_code == 200
     assert requests.head(PI4_SHORTLINK, allow_redirects=True).status_code == 200
-    assert requests.head(PI4_SHORTLINK_MD5, allow_redirects=True).status_code == 200
+    assert requests.head(PI4_SHORTLINK_SHA256, allow_redirects=True).status_code == 200
     print("All shortlinks are working")
 
 


### PR DESCRIPTION
- As per the `redirects.csv`, replaced old MD5 image hash links with the SHA256 links. 
-  The older links are failing in the action as they're not valid anymore. [ Failed Action ](https://github.com/Screenly/Quality-Control/actions/runs/17814036766/job/50643814761)
- The new links have been tested and are working properly on my local machine. 
```
python test_disk_image_downloads.py               
Testing shortlinks
All shortlinks are working
Testing Raspberry Pi Imager URLs for Anthias
https://github.com/Screenly/Anthias/releases/download/v0.20.3/2025-07-12-raspberry-pi.img.zst
https://github.com/Screenly/Anthias/releases/download/v0.20.3/2025-07-12-raspberry-pi2.img.zst
https://github.com/Screenly/Anthias/releases/download/v0.20.3/2025-07-12-raspberrypi3.img.zst
https://github.com/Screenly/Anthias/releases/download/v0.20.3/2025-07-12-raspberrypi4-64.img.zst
https://github.com/Screenly/Anthias/releases/download/v0.20.3/2025-07-12-raspberrypi5.img.zst
Testing Raspberry Pi Imager URLs for Screenly
https://disk-images.screenlyapp.com/screenly-3.8.4-r2-pi3.img.zip
https://disk-images.screenlyapp.com/screenly-4.1.1-pi64-stable.img.zip
```
