### PR TITLE
Add `workflow-keepalive` on automated QC test action file. 

### DIFF
--- a/.github/workflows/automated-quality-control.yml
+++ b/.github/workflows/automated-quality-control.yml
@@ -23,3 +23,11 @@ jobs:
           SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}
         run: |
           python -u automated_quality_control.py
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c #v1


### PR DESCRIPTION
We observed that the `automated-quality-control.yml` action gets disabled after some time, despite having `workflow-keepalive` enabled in our `test-disk-images.yml`. This suggests that we need to include workflow-keepalive in each workflow file to prevent them from being disabled. 

- Reference [Featured request: keepalive another workflow that's not a part of keepalive workflow ](https://github.com/liskin/gh-workflow-keepalive/issues/3)

- [X] Add `workflow-keepalive` on automated QC test action file. 