### PR TITLE
Switch API base URL from v4 to v4.1

### DIFF
--- a/.github/workflows/automated-quality-control.yml
+++ b/.github/workflows/automated-quality-control.yml
@@ -24,6 +24,7 @@ jobs:
           API_BASE_URL: ${{ vars.API_BASE_URL }}
         run: |
           set -euo pipefail
+          API_BASE_URL="${API_BASE_URL:-https://api.screenlyapp.com}"
           current_user=$(
             curl -fsSL -H "Authorization: Token ${SCREENLY_API_TOKEN}" \
               "${API_BASE_URL}/api/v4.1/users" \

--- a/.github/workflows/automated-quality-control.yml
+++ b/.github/workflows/automated-quality-control.yml
@@ -18,6 +18,27 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Screenly API whoami
+        env:
+          SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}
+          API_BASE_URL: ${{ vars.API_BASE_URL }}
+        run: |
+          set -euo pipefail
+          API_BASE_URL="${API_BASE_URL:-https://api.screenlyapp.com}"
+          current_user=$(
+            curl -fsSL -H "Authorization: Token ${SCREENLY_API_TOKEN}" \
+              "${API_BASE_URL}/api/v4.1/users" \
+              | jq -r '.[0] | "\(.first_name) \(.last_name) <\(.email)>"'
+          )
+          echo "Current user: ${current_user}"
+          current_team=$(
+            curl -fsSL -H "Authorization: Token ${SCREENLY_API_TOKEN}" \
+              "${API_BASE_URL}/api/v4.1/teams" \
+              | jq -r '.[] | select(.is_current == true)
+                      | "\(.name) (\(.domain)) — role: \(.role), permissions: \(.permissions)"'
+          )
+          echo "Current team: ${current_team}"
+
       - name: Run automated QC script
         env:
           SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}

--- a/.github/workflows/automated-quality-control.yml
+++ b/.github/workflows/automated-quality-control.yml
@@ -18,27 +18,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Screenly API whoami
-        env:
-          SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}
-          API_BASE_URL: ${{ vars.API_BASE_URL }}
-        run: |
-          set -euo pipefail
-          API_BASE_URL="${API_BASE_URL:-https://api.screenlyapp.com}"
-          current_user=$(
-            curl -fsSL -H "Authorization: Token ${SCREENLY_API_TOKEN}" \
-              "${API_BASE_URL}/api/v4.1/users" \
-              | jq -r '.[0] | "\(.first_name) \(.last_name) <\(.email)>"'
-          )
-          echo "Current user: ${current_user}"
-          current_team=$(
-            curl -fsSL -H "Authorization: Token ${SCREENLY_API_TOKEN}" \
-              "${API_BASE_URL}/api/v4.1/teams" \
-              | jq -r '.[] | select(.is_current == true)
-                      | "\(.name) (\(.domain)) — role: \(.role), permissions: \(.permissions)"'
-          )
-          echo "Current team: ${current_team}"
-
       - name: Run automated QC script
         env:
           SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}

--- a/.github/workflows/automated-quality-control.yml
+++ b/.github/workflows/automated-quality-control.yml
@@ -18,27 +18,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Screenly API whoami
-        env:
-          SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}
-          API_BASE_URL: ${{ vars.API_BASE_URL }}
-        run: |
-          set -euo pipefail
-          API_BASE_URL="${API_BASE_URL:-https://api.screenlyapp.com}"
-          current_user=$(
-            curl -fsSL -H "Authorization: Token ${SCREENLY_API_TOKEN}" \
-              "${API_BASE_URL}/api/v4.1/users" \
-              | jq -r '.[0] | "\(.first_name) \(.last_name) <\(.email)>"'
-          )
-          echo "Current user: ${current_user}"
-          current_team=$(
-            curl -fsSL -H "Authorization: Token ${SCREENLY_API_TOKEN}" \
-              "${API_BASE_URL}/api/v4.1/teams" \
-              | jq -r '.[] | select(.is_current == true)
-                      | "\(.name) (\(.domain))"'
-          )
-          echo "Current team: ${current_team}"
-
       - name: Run automated QC script
         env:
           SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}

--- a/.github/workflows/automated-quality-control.yml
+++ b/.github/workflows/automated-quality-control.yml
@@ -18,6 +18,26 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Screenly API whoami
+        env:
+          SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}
+          API_BASE_URL: ${{ vars.API_BASE_URL }}
+        run: |
+          set -euo pipefail
+          current_user=$(
+            curl -fsSL -H "Authorization: Token ${SCREENLY_API_TOKEN}" \
+              "${API_BASE_URL}/api/v4.1/users" \
+              | jq -r '.[0] | "\(.first_name) \(.last_name) <\(.email)>"'
+          )
+          echo "Current user: ${current_user}"
+          current_team=$(
+            curl -fsSL -H "Authorization: Token ${SCREENLY_API_TOKEN}" \
+              "${API_BASE_URL}/api/v4.1/teams" \
+              | jq -r '.[] | select(.is_current == true)
+                      | "\(.name) (\(.domain))"'
+          )
+          echo "Current team: ${current_team}"
+
       - name: Run automated QC script
         env:
           SCREENLY_API_TOKEN: ${{ secrets.SCREENLY_API_TOKEN }}

--- a/automated_quality_control.py
+++ b/automated_quality_control.py
@@ -180,7 +180,6 @@ def assign_playlist_to_all_screens(playlist_id):
     response.raise_for_status()
 
 
-@retry((requests.HTTPError,), tries=20, delay=5)
 def create_qc_playlist():
     """
     Create a new QC playlist, populate it with random assets,

--- a/automated_quality_control.py
+++ b/automated_quality_control.py
@@ -102,7 +102,7 @@ def get_qc_playlist_ids():
 
 def delete_playlist(playlist_id):
     """
-    Delete a playlist and its items. In v4, playlist items must be
+    Delete a playlist and its items. Playlist items must be
     removed before the playlist itself can be deleted.
     """
     items_response = requests.delete(
@@ -135,7 +135,7 @@ def get_all_screens_label_id():
 
 def add_asset_to_playlist(playlist_id, asset_id):
     """
-    Add a single asset to a playlist via the v4 playlist-items endpoint.
+    Add a single asset to a playlist via the playlist-items endpoint.
     """
     payload = {
         "playlist_id": playlist_id,

--- a/automated_quality_control.py
+++ b/automated_quality_control.py
@@ -180,7 +180,7 @@ def assign_playlist_to_all_screens(playlist_id):
     response.raise_for_status()
 
 
-@retry((requests.HTTPError,), tries=3, delay=5)
+@retry((requests.HTTPError,), tries=20, delay=5)
 def create_qc_playlist():
     """
     Create a new QC playlist, populate it with random assets,

--- a/automated_quality_control.py
+++ b/automated_quality_control.py
@@ -64,10 +64,10 @@ def wait_for_screens_to_sync():
         print(f"Unable to fetch screens: {error}")
         sys.exit(1)
 
-    screens_not_in_sync = [screen for screen in screens if not screen['in_sync']]
+    screens_not_in_sync = [screen for screen in screens if not screen['screen_statuses']['in_sync']]
 
-    offline_screens = [s for s in screens_not_in_sync if s['status'].lower() == 'offline']
-    out_of_sync_screens = [s for s in screens_not_in_sync if s['status'].lower() != 'offline']
+    offline_screens = [s for s in screens_not_in_sync if s['screen_statuses']['status'].lower() == 'offline']
+    out_of_sync_screens = [s for s in screens_not_in_sync if s['screen_statuses']['status'].lower() != 'offline']
 
     if offline_screens:
         print(f"Skipping {len(offline_screens)} offline screen(s) (cannot sync while unreachable):")
@@ -79,7 +79,7 @@ def wait_for_screens_to_sync():
 
     print(f"...waiting for {len(out_of_sync_screens)} screen(s) to sync:")
     for screen in out_of_sync_screens:
-        print(f"  OUT OF SYNC: {screen['name']}({screen['hostname']}) — {screen['status'].lower()}")
+        print(f"  OUT OF SYNC: {screen['name']}({screen['hostname']}) — {screen['screen_statuses']['status'].lower()}")
 
     raise AssertionError("Not all online screens synchronized")
 
@@ -243,14 +243,14 @@ def main():
         print(f"Warning: {error}. Fetching final screen status...")
         try:
             final_screens = get_screens()
-            not_synced = [s for s in final_screens if not s['in_sync']]
-            offline = [s for s in not_synced if s['status'].lower() == 'offline']
-            out_of_sync = [s for s in not_synced if s['status'].lower() != 'offline']
+            not_synced = [s for s in final_screens if not s['screen_statuses']['in_sync']]
+            offline = [s for s in not_synced if s['screen_statuses']['status'].lower() == 'offline']
+            out_of_sync = [s for s in not_synced if s['screen_statuses']['status'].lower() != 'offline']
             print(f"Final status: {len(offline)} offline, {len(out_of_sync)} out of sync after timeout:")
             for s in offline:
                 print(f"  OFFLINE: {s['name']}({s['hostname']})")
             for s in out_of_sync:
-                print(f"  OUT OF SYNC: {s['name']}({s['hostname']}) — {s['status'].lower()}")
+                print(f"  OUT OF SYNC: {s['name']}({s['hostname']}) — {s['screen_statuses']['status'].lower()}")
         except Exception as fetch_error:
             print(f"Could not fetch final screen status: {fetch_error}")
 

--- a/automated_quality_control.py
+++ b/automated_quality_control.py
@@ -43,7 +43,7 @@ def get_screens() -> List[Dict[str, Any]]:
     Return a list of screens in the account.
     """
 
-    response = requests.get('https://api.screenlyapp.com/v4.1/screens?select=id,name,hostname,status,in_sync&type=eq.hardware&is_enabled=eq.true', headers=REQUEST_HEADERS)
+    response = requests.get('https://api.screenlyapp.com/v4.1/screens?select=id,name,hostname,screen_statuses(status,in_sync)&type=eq.hardware&is_enabled=eq.true', headers=REQUEST_HEADERS)
     response.raise_for_status()
     return response.json()
 

--- a/automated_quality_control.py
+++ b/automated_quality_control.py
@@ -66,8 +66,14 @@ def wait_for_screens_to_sync():
 
     screens_not_in_sync = [screen for screen in screens if not screen['screen_statuses']['in_sync']]
 
-    offline_screens = [s for s in screens_not_in_sync if s['screen_statuses']['status'].lower() == 'offline']
-    out_of_sync_screens = [s for s in screens_not_in_sync if s['screen_statuses']['status'].lower() != 'offline']
+    offline_screens = []
+    out_of_sync_screens = []
+    for screen in screens_not_in_sync:
+        screen_statuses = screen['screen_statuses']
+        if screen_statuses['status'].lower() == 'offline':
+            offline_screens.append(screen)
+        else:
+            out_of_sync_screens.append(screen)
 
     if offline_screens:
         print(f"Skipping {len(offline_screens)} offline screen(s) (cannot sync while unreachable):")
@@ -79,7 +85,9 @@ def wait_for_screens_to_sync():
 
     print(f"...waiting for {len(out_of_sync_screens)} screen(s) to sync:")
     for screen in out_of_sync_screens:
-        print(f"  OUT OF SYNC: {screen['name']}({screen['hostname']}) — {screen['screen_statuses']['status'].lower()}")
+        screen_statuses = screen['screen_statuses']
+        status = screen_statuses['status'].lower()
+        print(f"  OUT OF SYNC: {screen['name']}({screen['hostname']}) — {status}")
 
     raise AssertionError("Not all online screens synchronized")
 
@@ -243,14 +251,22 @@ def main():
         print(f"Warning: {error}. Fetching final screen status...")
         try:
             final_screens = get_screens()
-            not_synced = [s for s in final_screens if not s['screen_statuses']['in_sync']]
-            offline = [s for s in not_synced if s['screen_statuses']['status'].lower() == 'offline']
-            out_of_sync = [s for s in not_synced if s['screen_statuses']['status'].lower() != 'offline']
+            not_synced = [screen for screen in final_screens if not screen['screen_statuses']['in_sync']]
+            offline = []
+            out_of_sync = []
+            for s in not_synced:
+                screen_statuses = s['screen_statuses']
+                if screen_statuses['status'].lower() == 'offline':
+                    offline.append(s)
+                else:
+                    out_of_sync.append(s)
             print(f"Final status: {len(offline)} offline, {len(out_of_sync)} out of sync after timeout:")
             for s in offline:
                 print(f"  OFFLINE: {s['name']}({s['hostname']})")
             for s in out_of_sync:
-                print(f"  OUT OF SYNC: {s['name']}({s['hostname']}) — {s['screen_statuses']['status'].lower()}")
+                screen_statuses = s['screen_statuses']
+                status = screen_statuses['status'].lower()
+                print(f"  OUT OF SYNC: {s['name']}({s['hostname']}) — {status}")
         except Exception as fetch_error:
             print(f"Could not fetch final screen status: {fetch_error}")
 

--- a/automated_quality_control.py
+++ b/automated_quality_control.py
@@ -180,6 +180,7 @@ def assign_playlist_to_all_screens(playlist_id):
     response.raise_for_status()
 
 
+@retry(requests.HTTPError, tries=3, delay=5)
 def create_qc_playlist():
     """
     Create a new QC playlist, populate it with random assets,

--- a/automated_quality_control.py
+++ b/automated_quality_control.py
@@ -180,7 +180,7 @@ def assign_playlist_to_all_screens(playlist_id):
     response.raise_for_status()
 
 
-@retry(requests.HTTPError, tries=3, delay=5)
+@retry((requests.HTTPError,), tries=3, delay=5)
 def create_qc_playlist():
     """
     Create a new QC playlist, populate it with random assets,

--- a/automated_quality_control.py
+++ b/automated_quality_control.py
@@ -27,13 +27,14 @@ def get_ten_random_assets():
     )
     response.raise_for_status()
 
-    asset_count = len(response.json())
+    assets = response.json()
+    asset_count = len(assets)
 
     # Pick 10 random assets
     asset_list = []
     for i in range(10):
         random_index = random.randint(0, asset_count - 1)
-        asset_list.append(response.json()[random_index]["id"])
+        asset_list.append(assets[random_index]["id"])
 
     return asset_list
 
@@ -64,13 +65,16 @@ def wait_for_screens_to_sync():
         print(f"Unable to fetch screens: {error}")
         sys.exit(1)
 
-    screens_not_in_sync = [screen for screen in screens if not screen['screen_statuses']['in_sync']]
+    screens_not_in_sync = [
+        screen for screen in screens
+        if not screen.get('screen_statuses', {}).get('in_sync', False)
+    ]
 
     offline_screens = []
     out_of_sync_screens = []
     for screen in screens_not_in_sync:
-        screen_statuses = screen['screen_statuses']
-        if screen_statuses['status'].lower() == 'offline':
+        screen_statuses = screen.get('screen_statuses', {})
+        if screen_statuses.get('status', '').lower() == 'offline':
             offline_screens.append(screen)
         else:
             out_of_sync_screens.append(screen)
@@ -85,8 +89,8 @@ def wait_for_screens_to_sync():
 
     print(f"...waiting for {len(out_of_sync_screens)} screen(s) to sync:")
     for screen in out_of_sync_screens:
-        screen_statuses = screen['screen_statuses']
-        status = screen_statuses['status'].lower()
+        screen_statuses = screen.get('screen_statuses', {})
+        status = screen_statuses.get('status', 'unknown').lower()
         print(f"  OUT OF SYNC: {screen['name']}({screen['hostname']}) — {status}")
 
     raise AssertionError("Not all online screens synchronized")
@@ -251,12 +255,15 @@ def main():
         print(f"Warning: {error}. Fetching final screen status...")
         try:
             final_screens = get_screens()
-            not_synced = [screen for screen in final_screens if not screen['screen_statuses']['in_sync']]
+            not_synced = [
+                screen for screen in final_screens
+                if not screen.get('screen_statuses', {}).get('in_sync', False)
+            ]
             offline = []
             out_of_sync = []
             for s in not_synced:
-                screen_statuses = s['screen_statuses']
-                if screen_statuses['status'].lower() == 'offline':
+                screen_statuses = s.get('screen_statuses', {})
+                if screen_statuses.get('status', '').lower() == 'offline':
                     offline.append(s)
                 else:
                     out_of_sync.append(s)
@@ -264,8 +271,8 @@ def main():
             for s in offline:
                 print(f"  OFFLINE: {s['name']}({s['hostname']})")
             for s in out_of_sync:
-                screen_statuses = s['screen_statuses']
-                status = screen_statuses['status'].lower()
+                screen_statuses = s.get('screen_statuses', {})
+                status = screen_statuses.get('status', 'unknown').lower()
                 print(f"  OUT OF SYNC: {s['name']}({s['hostname']}) — {status}")
         except Exception as fetch_error:
             print(f"Could not fetch final screen status: {fetch_error}")

--- a/automated_quality_control.py
+++ b/automated_quality_control.py
@@ -22,7 +22,7 @@ def get_ten_random_assets():
     """
 
     response = requests.get(
-        'https://api.screenlyapp.com/v4/assets?select=id&type=in.("appweb","audio","edge-app","image","video","web")&status=in.("finished","processing")',
+        'https://api.screenlyapp.com/v4.1/assets?select=id&type=in.("appweb","audio","edge-app","image","video","web")&status=in.("finished","processing")',
         headers=REQUEST_HEADERS,
     )
     response.raise_for_status()
@@ -43,7 +43,7 @@ def get_screens() -> List[Dict[str, Any]]:
     Return a list of screens in the account.
     """
 
-    response = requests.get('https://api.screenlyapp.com/v4/screens?select=id,name,hostname,status,in_sync&type=eq.hardware&is_enabled=eq.true', headers=REQUEST_HEADERS)
+    response = requests.get('https://api.screenlyapp.com/v4.1/screens?select=id,name,hostname,status,in_sync&type=eq.hardware&is_enabled=eq.true', headers=REQUEST_HEADERS)
     response.raise_for_status()
     return response.json()
 
@@ -89,7 +89,7 @@ def get_qc_playlist_ids():
     Get all playlists starting with 'PLAYLIST_PREFIX'.
     """
 
-    response = requests.get("https://api.screenlyapp.com/v4/playlists", headers=REQUEST_HEADERS)
+    response = requests.get("https://api.screenlyapp.com/v4.1/playlists", headers=REQUEST_HEADERS)
     response.raise_for_status()
 
     qc_playlists = []
@@ -106,13 +106,13 @@ def delete_playlist(playlist_id):
     removed before the playlist itself can be deleted.
     """
     items_response = requests.delete(
-        f"https://api.screenlyapp.com/v4/playlist-items?playlist_id=eq.{playlist_id}",
+        f"https://api.screenlyapp.com/v4.1/playlist-items?playlist_id=eq.{playlist_id}",
         headers=REQUEST_HEADERS,
     )
     if not items_response.ok:
         return False
     response = requests.delete(
-        f"https://api.screenlyapp.com/v4/playlists?id=eq.{playlist_id}",
+        f"https://api.screenlyapp.com/v4.1/playlists?id=eq.{playlist_id}",
         headers=REQUEST_HEADERS,
     )
     return response.ok
@@ -123,7 +123,7 @@ def get_all_screens_label_id():
     Return the ID of the built-in 'all-screens' label.
     """
     response = requests.get(
-        "https://api.screenlyapp.com/v4/labels?type=eq.all-screens",
+        "https://api.screenlyapp.com/v4.1/labels?type=eq.all-screens",
         headers=REQUEST_HEADERS,
     )
     response.raise_for_status()
@@ -143,7 +143,7 @@ def add_asset_to_playlist(playlist_id, asset_id):
         "duration": 10,
     }
     response = requests.post(
-        "https://api.screenlyapp.com/v4/playlist-items",
+        "https://api.screenlyapp.com/v4.1/playlist-items",
         headers={**REQUEST_HEADERS, "Prefer": "return=representation"},
         json=payload,
     )
@@ -161,7 +161,7 @@ def assign_playlist_to_all_screens(playlist_id):
         "playlist_id": playlist_id,
     }
     response = requests.post(
-        "https://api.screenlyapp.com/v4/labels/playlists",
+        "https://api.screenlyapp.com/v4.1/labels/playlists",
         headers={**REQUEST_HEADERS, "Prefer": "return=representation"},
         json=payload,
     )
@@ -184,7 +184,7 @@ def create_qc_playlist():
     }
 
     response = requests.post(
-        "https://api.screenlyapp.com/v4/playlists",
+        "https://api.screenlyapp.com/v4.1/playlists",
         headers={**REQUEST_HEADERS, "Prefer": "return=representation"},
         json=payload,
     )


### PR DESCRIPTION
## Summary

- Updated all Screenly API endpoint URLs from `/v4/` to `/v4.1/` across `automated_quality_control.py`
