### PR TITLE
Fix: bump vulnerable dependencies (14.07.2026)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2024.7.4
 charset-normalizer==3.3.2
-idna==3.7
-requests==2.32.4
-urllib3==2.6.3
+idna==3.15
+requests==2.33.1
+urllib3==2.7.0
 retry==0.9.2
 zstandard==0.23.0


### PR DESCRIPTION
## Summary
Resolves 4 open Dependabot alerts by bumping pinned dependencies in `requirements.txt` to their patched releases: `idna` 3.7→3.15 (regex DoS), `urllib3` 2.6.3→2.7.0 (cross-origin header leak on low-level redirects, decompression-bomb bypass), and `requests` 2.32.4→2.33.1 (insecure temp file reuse in `extract_zipped_paths`). None of these are used in ways that trigger the vulnerable code paths directly, but staying patched avoids exposure through transitive usage.

## Test plan
- Verified `pip install -r requirements.txt` resolves cleanly with the new pins
- Confirmed the existing test suite behaves identically before and after the bump (one pre-existing, unrelated fixture error in `test_disk_image_downloads.py`)