### PR TITLE
Fix QC playlist cleanup

### DIFF
--- a/automated_quality_control.py
+++ b/automated_quality_control.py
@@ -125,23 +125,35 @@ def get_qc_playlist_ids():
 
 def delete_playlist(playlist_id):
     """
-    Delete a playlist and its items. In v4.1, label associations and playlist
-    items must be removed before the playlist itself can be deleted.
+    Delete a QC playlist. In v4.1, label associations must be removed first,
+    and DELETE /labels/playlists requires a label_id filter.
+    Playlist items are left for the API to cascade with the playlist.
     """
-    labels_response = requests.delete(
+    associations_response = requests.get(
         f"{SCREENLY_API_BASE_URL}/v4.1/labels/playlists?playlist_id=eq.{playlist_id}",
         headers=REQUEST_HEADERS,
     )
-    if not labels_response.ok:
-        print(f"Failed to delete label associations for playlist {playlist_id}: {labels_response.status_code} {labels_response.text}")
+    if not associations_response.ok:
+        print(
+            f"Failed to fetch label associations for playlist {playlist_id}: "
+            f"{associations_response.status_code} {associations_response.text}"
+        )
         return False
-    items_response = requests.delete(
-        f"{SCREENLY_API_BASE_URL}/v4.1/playlist-items?playlist_id=eq.{playlist_id}",
-        headers=REQUEST_HEADERS,
-    )
-    if not items_response.ok:
-        print(f"Failed to delete items for playlist {playlist_id}: {items_response.status_code} {items_response.text}")
-        return False
+
+    for association in associations_response.json():
+        label_id = association["label_id"]
+        labels_response = requests.delete(
+            f"{SCREENLY_API_BASE_URL}/v4.1/labels/playlists"
+            f"?label_id=eq.{label_id}&playlist_id=eq.{playlist_id}",
+            headers=REQUEST_HEADERS,
+        )
+        if not labels_response.ok:
+            print(
+                f"Failed to delete label association {label_id} for playlist {playlist_id}: "
+                f"{labels_response.status_code} {labels_response.text}"
+            )
+            return False
+
     response = requests.delete(
         f"{SCREENLY_API_BASE_URL}/v4.1/playlists?id=eq.{playlist_id}",
         headers=REQUEST_HEADERS,


### PR DESCRIPTION
## Summary
- fetch label associations before deleting a QC playlist
- unlink each association using both `label_id` and `playlist_id`, as required by the v4.1 API
- delete the playlist without explicitly deleting its playlist items

## Root cause
The API rejects label-association deletion when only `playlist_id` is supplied. The cleanup returned early after that `400` response, so every scheduled run created another QC playlist without removing the previous one.

## Scope
Cleanup continues to select playlists whose titles start with the `QC` prefix. Other playlist titles are not selected.

## Test plan
- [x] Validated Python syntax with `ast.parse`
- [x] Checked the diff for whitespace errors
- [x] Confirmed the corrected API sequence against the account by removing 165 accumulated QC playlists with zero failures
- [X] Run the automated QC workflow and confirm the previous QC playlist is removed before the next one is created